### PR TITLE
fix: use `ytsr` filter to improve search reliability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10393,19 +10393,11 @@
       }
     },
     "ytsr": {
-      "version": "2.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/ytsr/-/ytsr-2.0.0-alpha.3.tgz",
-      "integrity": "sha512-NELl/ubEnBxxU/AofsXu8p6T2BArf/ROLOocblTgeSr7oNPPn6jPv57MCT4cIWJdzxWiHcdl6BqrypoIPejfmw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ytsr/-/ytsr-3.2.1.tgz",
+      "integrity": "sha512-iN2woG5bfXiAWs9Tv6MPVGx3f1zdpeshyevGAbm0ggCYLmOnSNIA3lkgqlkfa0CH5WKIB/yjwRPU1hc49AUN+g==",
       "requires": {
-        "html-entities": "^1.3.1",
         "miniget": "^4.1.0"
-      },
-      "dependencies": {
-        "miniget": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/miniget/-/miniget-4.1.0.tgz",
-          "integrity": "sha512-kzhrNv5L7LlomwGmPGQsLQ2PnT1LeJJWfB0wNFGyv426gEM1gsfziBQmfkr6XOBA8EusZg9nowlNT5CbuKTjZg=="
-        }
       }
     }
   }

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "request": "^2.88.2",
     "tmp": "^0.2.1",
     "ytdl-core": "^4.1.5",
-    "ytsr": "^2.0.0-alpha.3"
+    "ytsr": "^3.2.1"
   },
   "devDependencies": {
     "@types/express": "^4.17.6",


### PR DESCRIPTION
since search results are filtered, you're not guaranteed to get 5 suggestions even with the over-fetch of 15; this uses `ytsr`'s filter to avoid fetching non-video items in the first place for an improvement in reliability (there doesn't seem to be one for "non-live" unfortunately)

(also pulls in `ytsr` updates + addresses breaking changes)