### PR TITLE
feat: add button for opening video in PiP

### DIFF
--- a/public/script.js.LICENSE.txt
+++ b/public/script.js.LICENSE.txt
@@ -1,0 +1,1 @@
+/*! https://mths.be/punycode v1.3.2 by @mathias */

--- a/public/script.js.LICENSE.txt
+++ b/public/script.js.LICENSE.txt
@@ -1,1 +1,0 @@
-/*! https://mths.be/punycode v1.3.2 by @mathias */

--- a/src/client/index.pug
+++ b/src/client/index.pug
@@ -72,6 +72,7 @@ html
                                     button#popout-button pop out video
                                     button#resync-button resync video
                                     button#external-button open video in tab
+                                    button#pip-button open PiP
                         .menu-panel-tab-toggle-container(role="tablist")
                             button.menu-panel-tab-toggle(role="tab" data-tab-toggle="playback/search") search
                             button.menu-panel-tab-toggle.active(role="tab" data-tab-toggle="playback/playlist") playlist

--- a/src/client/main.ts
+++ b/src/client/main.ts
@@ -250,6 +250,19 @@ export async function load() {
         window.open(player.playingItem?.media.src);
     });
 
+    const pipButton = document.getElementById('pip-button') as HTMLButtonElement;
+    if (document.pictureInPictureEnabled) {
+        pipButton.addEventListener('click', () => {
+            video.requestPictureInPicture();
+        });
+        // resync when closing PiP to avoid automatically pausing
+        video.addEventListener('leavepictureinpicture', () => {
+            player.forceRetry('left PiP');
+        });
+    } else {
+        pipButton.hidden = true;
+    }
+
     const player = new Player(video);
     const zoneLogo = document.createElement('img');
     zoneLogo.src = 'zone-logo.png';
@@ -853,7 +866,7 @@ export async function load() {
         }
 
         const logo = player.hasItem ? audioLogo : undefined;
-        sceneRenderer.mediaElement = popoutPanel.hidden && player.hasVideo ? video : logo;
+        sceneRenderer.mediaElement = popoutPanel.hidden && player.hasVideo && !document.pictureInPictureElement ? video : logo;
 
         sceneRenderer.render();
     }


### PR DESCRIPTION
note: doesn't work in firefox yet (ff has PiP support but hasn't implemented the js api for it)

ref: https://developer.mozilla.org/en-US/docs/Web/API/Picture-in-Picture_API